### PR TITLE
Remove explicit use of /usr/include

### DIFF
--- a/fm-radio-app.pro
+++ b/fm-radio-app.pro
@@ -5,8 +5,6 @@ CONFIG += c++11
 
 SOURCES += main.cpp
 
-INCLUDEPATH += /usr/include
-
 target.path = /usr/bin
 
 RESOURCES += qml.qrc


### PR DESCRIPTION
[GDP-411] App fails to build for cross compile
