### PR TITLE
manifest: Change to .desktop file format

### DIFF
--- a/com.genivi.gdp.fmradio.desktop
+++ b/com.genivi.gdp.fmradio.desktop
@@ -1,4 +1,6 @@
+[Desktop Entry]
 Name=FM Radio
+Type=Application
 Icon=file://opt/com.genivi.gdp.fmradio/share/icons/com.genivi.gdp.fmradio.svg
 Unit=com.genivi.gdp.fmradio
-Exec=/opt/com.genivi.gdp.fmradio/bin/fm-radio-app
+Exec=/opt/com.genivi.gdp.fmradio/bin/fm-radio-app -platform wayland

--- a/com.genivi.gdp.fmradio.service
+++ b/com.genivi.gdp.fmradio.service
@@ -1,6 +1,0 @@
-[Unit]
-Description=FM Radio HMI
-
-[Service]
-Environment=LD_PRELOAD=/usr/lib/libEGL.so
-ExecStart=/opt/com.genivi.gdp.fmradio/bin/fm-radio-app -platform wayland


### PR DESCRIPTION
Remove .service file as it is no longer used by the HMI
Reformat .app file a to .desktop file

[GDP-555] Mechanism to register & launch apps in HMI

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>