### PR TITLE
 FM-radio: Remove HMI colliding surface id

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3,7 +3,7 @@
 
 //#include <systemd/sd-journal.h>
 
-#define FM_RADIO_SURFACE_ID 3
+
 
 int main(int argc, char *argv[])
 {
@@ -16,7 +16,6 @@ int main(int argc, char *argv[])
 
     QQuickView view(QUrl(QStringLiteral("qrc:/Main.qml")));
 
-    view.setProperty("IVI-Surface-ID", FM_RADIO_SURFACE_ID);
     view.show();
 
     return app.exec();


### PR DESCRIPTION
Removed colliding surface id from code as described.

[GDP-519] HMI have colliding surface ids

Signed-off-by: Canberk KOÇ <canberkkoc@gmail.com>